### PR TITLE
WIP: Habilita a criação de usuário em ambientes dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.env
+
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ docker-compose run api_users bash -c  "yarn && yarn jest --coverage --forceExit"
 
 O arquivo .env possui configurações iniciais que podem ser alteradas de acordo com a necessidade. São elas:
  - SECRET: chave para criptografia das senhas
+ - API_CONTEXT: indica o contexto que a aplicação está rodando, em ambientes que não o `production` não é necessário o envio de email na criação do usuário. Valores possíveis: (dev | production)
  - DB_USER: usuário de acesso ao banco de dados
  - DB_PASS: senha de acesso ao banco de dados
  - DB_NAME: nome da base de dados
@@ -38,6 +39,7 @@ Veja o exemplo abaixo:
 
 ```
 SECRET=chavedesegredo
+API_CONTEXT=dev
 DB_USER=api_user
 DB_PASS=api_password
 DB_NAME=api_database

--- a/src/Services/UserService.js
+++ b/src/Services/UserService.js
@@ -1,0 +1,69 @@
+const moment = require("moment-timezone");
+const User = require("../Models/UserSchema");
+const hash = require("../Utils/hashPass");
+const mailer = require("../Utils/mailer");
+
+const createUserWithTemporaryPass = async (userBody) => {
+  const { name, email, role, sector, image, temporaryPassword } = userBody;
+
+  const { transporter } = mailer;
+
+  try {
+    const user = await User.create({
+      name,
+      email,
+      role,
+      sector,
+      image,
+      pass: await hash.hashPass(temporaryPassword),
+      temporaryPassword: true,
+      createdAt: moment
+        .utc(moment.tz("America/Sao_Paulo").format("YYYY-MM-DDTHH:mm:ss"))
+        .toDate(),
+      updatedAt: moment
+        .utc(moment.tz("America/Sao_Paulo").format("YYYY-MM-DDTHH:mm:ss"))
+        .toDate(),
+    });
+
+    transporter.sendMail({
+      from: process.env.email,
+      to: email,
+      subject: "Senha temporária SiGeD",
+      text: `A sua senha temporária é: ${temporaryPassword}`,
+    });
+    return user;
+  } catch (error) {
+    throw error;
+  }
+};
+
+const createUserWithDefinitePass = async (userBody) => {
+  const { name, email, role, sector, image, pass } = userBody;
+
+  try {
+    const user = await User.create({
+      name,
+      email,
+      role,
+      sector,
+      image,
+      pass: await hash.hashPass(pass),
+      temporaryPassword: false,
+      createdAt: moment
+        .utc(moment.tz("America/Sao_Paulo").format("YYYY-MM-DDTHH:mm:ss"))
+        .toDate(),
+      updatedAt: moment
+        .utc(moment.tz("America/Sao_Paulo").format("YYYY-MM-DDTHH:mm:ss"))
+        .toDate(),
+    });
+
+    return user;
+  } catch (error) {
+    throw error;
+  }
+};
+
+module.exports = {
+  createUserWithTemporaryPass,
+  createUserWithDefinitePass,
+};


### PR DESCRIPTION
## Descrição

Adiciona nova variável de ambiente para selecionar o contexto em que a api está sendo executada: "dev | production"

Habilita a criação de usuários sem a necessidade de envio de email com senha temporária para ambientes que não são o de produção.